### PR TITLE
fix: Commands not being added

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains a collection of packages aimed to make working with Firebase 
 
 You can mix and match those packages as you wish.
 
-For example, you can only use `firebase-rules-coverage` to generate coverage reports, or only `firebase-rules-generator` to split your rules across different files.  
+For example, you can only use `@simpleclub/firebase-rules-coverage` to generate coverage reports, or only `@simpleclub/firebase-rules-generator` to split your rules across different files.  
 Or you can also split your rules across different files and then generate coverage reports on those files.
 
 ---

--- a/firebase-rules-coverage/CHANGELOG.md
+++ b/firebase-rules-coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @simpleclub/firebase-rules-coverage
 
+## 0.1.1
+
+- Fixes command `firebase-build-coverage` not being added to the project after installation.
+- Fixes package name in README.
+
 ## 0.1.0
 
 - Initial release

--- a/firebase-rules-coverage/README.md
+++ b/firebase-rules-coverage/README.md
@@ -16,16 +16,16 @@ This package aims to bridge this gap and converts the official Firebase test rep
 
 ## Installation
 
-The `firebase-rules-coverage` package is available on NPM (also GitHub Packages):
+The `@simpleclub/firebase-rules-coverage` package is available on NPM (also GitHub Packages):
 
 ```shell
-$ npm install --save firebase-rules-coverage
+$ npm install --save @simpleclub/firebase-rules-coverage
 ```
 
 Via Yarn:
 
 ```shell
-$ yarn add firebase-rules-coverage
+$ yarn add @simpleclub/firebase-rules-coverage
 ```
 
 ## Usage

--- a/firebase-rules-coverage/package.json
+++ b/firebase-rules-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleclub/firebase-rules-coverage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Analyze Firebase rules coverage data to covert it to LCOV.",
   "main": "build/src/index.js",
   "repository": "https://github.com/simpleclub/firebase-rules-helper",

--- a/firebase-rules-coverage/package.json
+++ b/firebase-rules-coverage/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "private": false,
   "bin": {
-    "firebase-rules-coverage": "build/src/cli.js"
+    "firebase-rules-coverage": "src/cli.js"
   },
   "engines": {
     "node": ">=12"

--- a/firebase-rules-generator/CHANGELOG.md
+++ b/firebase-rules-generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @simpleclub/firebase-rules-generator
 
+## 0.1.1
+
+- Fixes command `firebase-build-rules` not being added to the project after installation.
+- Fixes package name in README.
+
 ## 0.1.0
 
 - Initial release

--- a/firebase-rules-generator/README.md
+++ b/firebase-rules-generator/README.md
@@ -17,16 +17,16 @@ See also [Firebase rules coverage] if you want to generate a test coverage repor
 
 ## Installation
 
-The `firebase-rules-generator` package is available on NPM (also GitHub Packages): 
+The `@simpleclub/firebase-rules-generator` package is available on NPM (also GitHub Packages): 
 
 ```shell
-$ npm install --save firebase-rules-generator
+$ npm install --save @simpleclub/firebase-rules-generator
 ```
 
 Via Yarn:
 
 ```shell
-$ yarn add firebase-rules-generator
+$ yarn add @simpleclub/firebase-rules-generator
 ```
 
 ## Usage

--- a/firebase-rules-generator/package.json
+++ b/firebase-rules-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleclub/firebase-rules-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Helper package for building more complex Firebase rules with support for imports.",
   "main": "build/src/index.js",
   "repository": "https://github.com/simpleclub/firebase-rules-helper",

--- a/firebase-rules-generator/package.json
+++ b/firebase-rules-generator/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "private": false,
   "bin": {
-    "firebase-rules-generator": "build/src/cli.js"
+    "firebase-rules-generator": "src/cli.js"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
## Description

- Fixes an issue where the command where not being added to the Node projects after installation.
- Fixes the installation instructions to use the proper package names.

## Related issues & PRs

n/a

[keywords]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

## Checklist

- [x] I have made myself familiar with the
  [contribution guide](https://github.com/simpleclub/firebase-rules-helper/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] I've bumped all versions and created entries in `CHANGELOG.md` for all affected packages.
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
