### PR TITLE
chore: Update CLA link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,6 @@ In order for us to review and merge your code, please follow the link and sign t
 [create pr]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [GitHub hub]: https://hub.github.com
 [ssh key]: https://help.github.com/articles/generating-ssh-keys
-[CLA]: https://bit.ly/simpleclub-cla
+[CLA]: https://cla-assistant.io/simpleclub/
 [versioning]: https://semver.org/
 [yarn]: https://classic.yarnpkg.com/en/docs/install/


### PR DESCRIPTION
## Description

We had to update the link after migrating the CLA tool: https://simpleclub.slack.com/archives/CATPELDMH/p1736153833672199?thread_ts=1733313483.185789&cid=CATPELDMH

Updates changes from https://github.com/simpleclub/firebase-rules-helper/pull/30

## Related issues & PRs

[SC-14984]

## Checklist

- [x] I have made myself familiar with the
  [contribution guide](https://github.com/simpleclub/firebase-rules-helper/blob/master/CONTRIBUTING.md).
- [ ] I added a PR description.
- [ ] I linked all related issues and PRs I could find (no links if there are none).
- [ ] I've bumped all versions and created entries in `CHANGELOG.md` for all affected packages.
- [ ] If there is new functionality in code, I added tests covering all my additions.
- [ ] All required checks pass.


[SC-14984]: https://simpleclub.atlassian.net/browse/SC-14984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ